### PR TITLE
Add export buttons to data table

### DIFF
--- a/bmh_sample_tracker/templates/base.html
+++ b/bmh_sample_tracker/templates/base.html
@@ -15,7 +15,7 @@
     <!-- Latest compiled and minified Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/css/bootstrap.min.css" integrity="sha512-SbiR/eusphKoMVVXysTKG/7VseWii+Y3FdHrt0EpKgpToZeemhqHeZeLWLhJutz/2ut2Vw1uQEj2MbRF+TVBUA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <!-- Your stuff: Third-party CSS libraries go here -->
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.11.2/datatables.min.css"/>
+    <link rel="stylesheet" href="https://cdn.datatables.net/v/bs5/dt-1.13.4/b-2.3.6/b-html5-2.3.6/b-print-2.3.6/datatables.min.css"/>
     <!-- This file stores project-specific CSS -->
     <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock %}
@@ -27,8 +27,8 @@
       <script defer src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.min.js" integrity="sha512-1/RvZTcCDEUjY/CypiMz+iqqtaoQfAITmNSJY17Myp4Ms5mdxPS5UV7iOfdZoxcGhzFbOm6sntTKJppjvuhg4g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
       <!-- Your stuff: Third-party javascript libraries go here -->
       <script type="text/javascript" src="//code.jquery.com/jquery-3.5.1.min.js"></script>
-      <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.11.2/datatables.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+      <script type="text/javascript" src="https://cdn.datatables.net/v/bs5/dt-1.13.4/b-2.3.6/b-html5-2.3.6/b-print-2.3.6/datatables.min.js"></script>
       <!-- place project specific Javascript in this file -->
       <script defer src="{% static 'js/project.js' %}"></script>
 

--- a/sample_database/templates/sample_database/index.html
+++ b/sample_database/templates/sample_database/index.html
@@ -96,6 +96,10 @@
       language: {
         search: 'Search all fields:',
       },
+      dom: 'Bfrtip', // Specify the Buttons extension
+      buttons: [
+        'copy', 'csv', 'excel', 'pdf', 'print' // Add the export buttons you want to include
+      ],
       initComplete: function () {
         // Apply the search
         this.api()


### PR DESCRIPTION
Currently copy to clipboard, csv, and printable output are supported (and apply to the subset of rows from searches)

I think an excel button *should* be showing up if the browser supports it but it ain't on my end. Between the copy and csv that should handle things though.