### PR TITLE
Add missing page length option

### DIFF
--- a/sample_database/templates/sample_database/index.html
+++ b/sample_database/templates/sample_database/index.html
@@ -45,6 +45,10 @@
         dataSrc: '',
       },
       order: [[0, 'desc']],
+      lengthMenu: [
+        [10, 50, 100, -1],
+        [10, 50, 100, 'All'],
+      ],
       columns: [
         {
           data: 'sample_id',
@@ -96,9 +100,9 @@
       language: {
         search: 'Search all fields:',
       },
-      dom: 'Bfrtip', // Specify the Buttons extension
+      dom: '<lf<t>ipB>',
       buttons: [
-        'copy', 'csv', 'excel', 'pdf', 'print' // Add the export buttons you want to include
+        'copy', 'csv', 'print'
       ],
       initComplete: function () {
         // Apply the search


### PR DESCRIPTION
Got accidentally deleted when I added the export buttons.

Also tweak the length options to be longer.

Don't try and fix the width because CSS is hard.